### PR TITLE
fix:Eliminar la línea require('dotenv').config(); de todos.routes.js.

### DIFF
--- a/back/routes/todos.routes.js
+++ b/back/routes/todos.routes.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+
 const express = require("express");
 const router = new express.Router();
 const pool = require("../mysql_conn.js");


### PR DESCRIPTION
El fichero todos.routes.js tiene require('dotenv').config() en la línea 1, pero server.js ya lo carga al inicio. No es necesario y puede causar confusión.