### PR TITLE
fix: añadir prefijo de servidor en todos los endpoints de front #115

### DIFF
--- a/front/js/index.js
+++ b/front/js/index.js
@@ -1,5 +1,5 @@
 // ------------------------------------ Formulario SignIn
-
+const API_URL = "http://localhost:3000";
 const forms = document.querySelectorAll("form");
 const signInRES = document.querySelector("#signInRES");
 const signUpRES = document.querySelector("#signUpRES");

--- a/front/js/index.js
+++ b/front/js/index.js
@@ -34,7 +34,7 @@ if (forms[0]) {
     btn.disabled = true;
 
     try {
-      const res = await fetch("/api/v1/signin", {
+      const res = await fetch((`${API_URL}/api/v1/singin`), {
         method: "post",
         body: JSON.stringify({ email, password }),
         headers: { "Content-Type": "application/json" },
@@ -103,7 +103,7 @@ if (forms[1]) {
     btn.disabled = true;
 
     try {
-      const res = await fetch("/api/v1/signup", {
+      const res = await fetch(`${API_URL}/api/v1/signup`, {
         method: "post",
         body: JSON.stringify({ email, password }),
         headers: { "Content-Type": "application/json" },

--- a/front/js/main.js
+++ b/front/js/main.js
@@ -1,3 +1,4 @@
+const API_URL = "http://localhost:3000";
 // ------------------------------------ Validación manual (sustituye a Joi)
 
 function validarEmail(email) {

--- a/front/js/main.js
+++ b/front/js/main.js
@@ -15,7 +15,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   if (!nav) return;
 
   try {
-    const res = await fetch("/api/v1/me");
+    const res = await fetch(`${API_URL}/api/v1/me`);
 
     if (res.ok) {
       nav.innerHTML = `
@@ -27,7 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       logoutBtn.addEventListener("click", async () => {
           try {
-              await fetch("/api/v1/logout", { method: "POST" });
+              await fetch(`${API_URL}/api/v1/logout`, { method: "POST" });
               localStorage.removeItem("accessToken");
               window.location.href = "/";
           } catch (error) {

--- a/front/js/main.js
+++ b/front/js/main.js
@@ -1,4 +1,4 @@
-const API_URL = "http://localhost:3000";
+
 // ------------------------------------ Validación manual (sustituye a Joi)
 
 function validarEmail(email) {

--- a/front/js/me.js
+++ b/front/js/me.js
@@ -1,3 +1,4 @@
+const API_URL = "http://localhost:3000";
 // ------------------------------------ Página Mi Cuenta
 
 document.addEventListener("DOMContentLoaded", async () => {

--- a/front/js/me.js
+++ b/front/js/me.js
@@ -8,7 +8,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   try {
 
-    const res = await fetch("/api/v1/me", {
+    const res = await fetch(`${API_URL}/api/v1/me`, {
       credentials: "include"
     });
 

--- a/front/js/me.js
+++ b/front/js/me.js
@@ -1,4 +1,4 @@
-const API_URL = "http://localhost:3000";
+
 // ------------------------------------ Página Mi Cuenta
 
 document.addEventListener("DOMContentLoaded", async () => {

--- a/front/js/todos.js
+++ b/front/js/todos.js
@@ -8,7 +8,7 @@ const tituloTarea = document.querySelector("#tituloTarea");
 // ------- -> LISTAR TAREAS <- -------
 
     try {
-        const res = await fetch("/api/v1/todos");
+        const res = await fetch(`${API_URL}/api/v1/todos`);
         if (!res.ok) return;
         const data = await res.json();
         const tareas = Array.isArray(data) ? data : (data.tasks || []);
@@ -35,7 +35,7 @@ const tituloTarea = document.querySelector("#tituloTarea");
     const titulo = e.target.tituloTarea.value;
 
     try {
-        const res = await fetch("/api/v1/todos", {
+        const res = await fetch(`${API_URL}/api/v1/todos`, {
             method: "post",
             body: JSON.stringify({ titulo }),
             headers: { "Content-Type": "application/json" },
@@ -70,7 +70,7 @@ tareasList.addEventListener("click", async (e) => {
   // Toggle completada
   if (e.target.classList.contains("check")) {
     try {
-        const res = await fetch(`/api/v1/todos/${id}`, {
+        const res = await fetch(`${API_URL}/api/v1/todos/${id}`, {
             method: "PUT",
         });
         if (!res.ok) return;
@@ -84,7 +84,7 @@ tareasList.addEventListener("click", async (e) => {
   // Eliminar
   if (e.target.tagName === "BUTTON") {
     try {
-        const res = await fetch(`/api/v1/todos/${id}`, {
+        const res = await fetch(`${API_URL}/api/v1/todos/${id}`, {
             method: "delete",
         });
         if (!res.ok) return;

--- a/front/js/todos.js
+++ b/front/js/todos.js
@@ -1,4 +1,4 @@
-const API_URL = "http://localhost:3000";
+
 
 document.addEventListener("DOMContentLoaded", async () => {
 

--- a/front/js/todos.js
+++ b/front/js/todos.js
@@ -1,3 +1,4 @@
+const API_URL = "http://localhost:3000";
 
 document.addEventListener("DOMContentLoaded", async () => {
 


### PR DESCRIPTION
Faltaba añadir la dirección y puerto del servidor en todos los endpoints de front (lo ideal sería declarar una variable nueva en el fichero .env y en cada fichero de front crear un variable que recoga el valor para encadenarlo al inicio del string de los endpoints en cada fetch).

La variable es API_URL

Localización de los endpoints a modificar:


index.js

líneas 37, 106

main.js

líneas 18, 30

me.js

línea 11

todos.js

línea 10, 46